### PR TITLE
fix(core): Updates VecEncoder to support anything that can be bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,12 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,16 +268,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -441,22 +425,21 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
- "num_cpus",
  "pin-project-lite",
  "tokio-macros",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -465,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -567,7 +550,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wasm-tokio"
-version = "0.5.16"
+version = "0.6.0"
 dependencies = [
  "futures",
  "leb128-tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tokio"
-version = "0.5.16"
+version = "0.6.0"
 description = "Streaming WebAssembly codec based on Tokio"
 
 authors.workspace = true

--- a/src/core.rs
+++ b/src/core.rs
@@ -367,10 +367,11 @@ where
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct CoreVecEncoderBytes;
 
-impl Encoder<&[u8]> for CoreVecEncoderBytes {
+impl<T: AsRef<[u8]>> Encoder<T> for CoreVecEncoderBytes {
     type Error = std::io::Error;
 
-    fn encode(&mut self, item: &[u8], dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let item = item.as_ref();
         let n = item.len();
         let n = u32::try_from(n)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
@@ -378,51 +379,6 @@ impl Encoder<&[u8]> for CoreVecEncoderBytes {
         Leb128Encoder.encode(n, dst)?;
         dst.extend_from_slice(item);
         Ok(())
-    }
-}
-
-impl Encoder<Vec<u8>> for CoreVecEncoderBytes {
-    type Error = std::io::Error;
-
-    fn encode(&mut self, item: Vec<u8>, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let item: &[u8] = item.as_ref();
-        self.encode(item, dst)
-    }
-}
-
-impl Encoder<&Vec<u8>> for CoreVecEncoderBytes {
-    type Error = std::io::Error;
-
-    fn encode(&mut self, item: &Vec<u8>, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let item: &[u8] = item.as_ref();
-        self.encode(item, dst)
-    }
-}
-
-impl Encoder<Bytes> for CoreVecEncoderBytes {
-    type Error = std::io::Error;
-
-    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let item: &[u8] = item.as_ref();
-        self.encode(item, dst)
-    }
-}
-
-impl Encoder<&Bytes> for CoreVecEncoderBytes {
-    type Error = std::io::Error;
-
-    fn encode(&mut self, item: &Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let item: &[u8] = item.as_ref();
-        self.encode(item, dst)
-    }
-}
-
-impl Encoder<Arc<[u8]>> for CoreVecEncoderBytes {
-    type Error = std::io::Error;
-
-    fn encode(&mut self, item: Arc<[u8]>, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let item: &[u8] = item.as_ref();
-        self.encode(item, dst)
     }
 }
 


### PR DESCRIPTION
This came from an issue when trying to pass a vec of tuples that had `Bytes` ended up as `&&Bytes` which there wasn't an impl for. When I looked at the implementation, it looked like pretty much everything was calling `AsRef` anyway, so I collapsed everything down to the single impl.